### PR TITLE
Add Flask HTMX blog with comment management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# public_test
-some codex test
+# Flask HTMX Blog
+
+Eine kleine Blog-Anwendung mit Flask als Backend und HTMX im Frontend. Du kannst neue Beiträge erstellen, Kommentare hinzufügen und bestehende Kommentare wieder löschen.
+
+## Voraussetzungen
+
+- Python 3.11
+
+## Installation & Start
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install flask
+flask --app app run
+```
+
+Die Anwendung legt beim ersten Start automatisch eine SQLite-Datenbank `blog.db` im Projektverzeichnis an.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Iterable
+
+from flask import Flask, Response, abort, redirect, render_template, request, url_for
+
+app = Flask(__name__)
+DATABASE = Path(app.root_path) / "blog.db"
+
+
+def get_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(DATABASE)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db() -> None:
+    DATABASE.parent.mkdir(parents=True, exist_ok=True)
+    with closing(get_connection()) as conn, conn, closing(conn.cursor()) as cursor:
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS posts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                body TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS comments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                post_id INTEGER NOT NULL,
+                author TEXT NOT NULL,
+                content TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY(post_id) REFERENCES posts(id) ON DELETE CASCADE
+            )
+            """
+        )
+
+        cursor.execute("SELECT COUNT(*) FROM posts")
+        if cursor.fetchone()[0] == 0:
+            cursor.execute(
+                "INSERT INTO posts (title, body) VALUES (?, ?)",
+                (
+                    "Willkommen in deinem Blog",
+                    "Dieser Beispielartikel zeigt, wie du Beiträge und Kommentare mit Flask und HTMX verwaltest.",
+                ),
+            )
+
+
+@app.before_first_request
+def before_first_request() -> None:
+    init_db()
+
+
+@app.route("/", methods=["GET", "POST"])
+def index() -> str:
+    if request.method == "POST":
+        title = request.form.get("title", "").strip()
+        body = request.form.get("body", "").strip()
+        if not title or not body:
+            abort(400, "Titel und Inhalt werden benötigt.")
+        with closing(get_connection()) as conn, conn, closing(conn.cursor()) as cursor:
+            cursor.execute("INSERT INTO posts (title, body) VALUES (?, ?)", (title, body))
+        return redirect(url_for("index"))
+
+    with closing(get_connection()) as conn, closing(conn.cursor()) as cursor:
+        cursor.execute(
+            "SELECT id, title, body, created_at, (SELECT COUNT(*) FROM comments WHERE post_id = posts.id) AS comment_count FROM posts ORDER BY created_at DESC"
+        )
+        posts = cursor.fetchall()
+    return render_template("index.html", posts=posts)
+
+
+@app.route("/posts/<int:post_id>")
+def post_detail(post_id: int) -> str:
+    with closing(get_connection()) as conn, closing(conn.cursor()) as cursor:
+        cursor.execute("SELECT id, title, body, created_at FROM posts WHERE id = ?", (post_id,))
+        post = cursor.fetchone()
+        if post is None:
+            abort(404)
+        comments = get_comments_for_post(cursor, post_id)
+    return render_template("post_detail.html", post=post, comments=comments)
+
+
+def get_comments_for_post(cursor: sqlite3.Cursor, post_id: int) -> Iterable[sqlite3.Row]:
+    cursor.execute(
+        "SELECT id, author, content, created_at FROM comments WHERE post_id = ? ORDER BY created_at DESC",
+        (post_id,),
+    )
+    return cursor.fetchall()
+
+
+@app.route("/posts/<int:post_id>/comments", methods=["POST"])
+def create_comment(post_id: int) -> str:
+    author = request.form.get("author", "Anonymous").strip() or "Anonymous"
+    content = request.form.get("content", "").strip()
+    if not content:
+        abort(400, "Kommentarinhalte dürfen nicht leer sein.")
+
+    with closing(get_connection()) as conn, conn, closing(conn.cursor()) as cursor:
+        cursor.execute("SELECT 1 FROM posts WHERE id = ?", (post_id,))
+        if cursor.fetchone() is None:
+            abort(404)
+        cursor.execute(
+            "INSERT INTO comments (post_id, author, content) VALUES (?, ?, ?)",
+            (post_id, author, content),
+        )
+        comments = get_comments_for_post(cursor, post_id)
+
+    return render_template("partials/comment_list.html", comments=comments, post_id=post_id)
+
+
+@app.route("/comments/<int:comment_id>", methods=["DELETE"])
+def delete_comment(comment_id: int) -> Response:
+    with closing(get_connection()) as conn, conn, closing(conn.cursor()) as cursor:
+        cursor.execute(
+            "SELECT post_id FROM comments WHERE id = ?",
+            (comment_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            abort(404)
+        (post_id,) = row
+        cursor.execute("DELETE FROM comments WHERE id = ?", (comment_id,))
+        comments = get_comments_for_post(cursor, post_id)
+
+    return render_template("partials/comment_list.html", comments=comments, post_id=post_id)
+
+
+if __name__ == "__main__":
+    init_db()
+    app.run(debug=True)

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,37 @@
+body {
+  padding-bottom: 3rem;
+}
+
+header h1 a {
+  text-decoration: none;
+}
+
+.subtitle {
+  color: var(--muted-color);
+}
+
+ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+article {
+  margin-bottom: 1.5rem;
+}
+
+article header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+article footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+button.secondary {
+  background-color: transparent;
+  border: 1px solid var(--muted-border-color);
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}Flask HTMX Blog{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@1.5.10/css/pico.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1><a href="{{ url_for('index') }}">Flask &amp; HTMX Blog</a></h1>
+        <p class="subtitle">Ein kompakter Blog mit Live-Kommentaren.</p>
+      </header>
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{% block title %}Beiträge - Flask HTMX Blog{% endblock %}
+
+{% block content %}
+<section>
+  <h2>Neuen Beitrag erstellen</h2>
+  <form method="post" class="grid">
+    <label>
+      Titel
+      <input type="text" name="title" required />
+    </label>
+    <label>
+      Inhalt
+      <textarea name="body" rows="4" required></textarea>
+    </label>
+    <button type="submit">Veröffentlichen</button>
+  </form>
+</section>
+
+<section>
+  <h2>Beiträge</h2>
+  {% if posts %}
+    <ul>
+      {% for post in posts %}
+        <li>
+          <article>
+            <header>
+              <h3><a href="{{ url_for('post_detail', post_id=post['id']) }}" hx-boost="true">{{ post['title'] }}</a></h3>
+              <small>{{ post['created_at'] }}</small>
+            </header>
+            <p>{{ post['body'] }}</p>
+            <footer>
+              <small>{{ post['comment_count'] }} Kommentare</small>
+              <a class="secondary" href="{{ url_for('post_detail', post_id=post['id']) }}" hx-boost="true">Kommentare ansehen</a>
+            </footer>
+          </article>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>Noch keine Beiträge vorhanden.</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/templates/partials/comment_list.html
+++ b/templates/partials/comment_list.html
@@ -1,0 +1,29 @@
+<div id="comments">
+  {% if comments %}
+    <ul>
+      {% for comment in comments %}
+        <li>
+          <article>
+            <header>
+              <strong>{{ comment['author'] }}</strong>
+              <small>{{ comment['created_at'] }}</small>
+            </header>
+            <p>{{ comment['content'] }}</p>
+            <footer>
+              <button
+                class="secondary"
+                hx-delete="{{ url_for('delete_comment', comment_id=comment['id']) }}"
+                hx-target="#comments"
+                hx-swap="outerHTML"
+              >
+                Löschen
+              </button>
+            </footer>
+          </article>
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>Noch keine Kommentare vorhanden.</p>
+  {% endif %}
+</div>

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block title %}{{ post['title'] }} - Flask HTMX Blog{% endblock %}
+
+{% block content %}
+<article>
+  <header>
+    <h2>{{ post['title'] }}</h2>
+    <small>{{ post['created_at'] }}</small>
+  </header>
+  <p>{{ post['body'] }}</p>
+</article>
+
+<section aria-labelledby="comments-title">
+  <h2 id="comments-title">Kommentare</h2>
+  {% include "partials/comment_list.html" %}
+
+  <h3>Neuen Kommentar schreiben</h3>
+  <form
+    hx-post="{{ url_for('create_comment', post_id=post['id']) }}"
+    hx-target="#comments"
+    hx-swap="outerHTML"
+    class="grid"
+  >
+    <label>
+      Name
+      <input type="text" name="author" placeholder="Anonymous" />
+    </label>
+    <label>
+      Kommentar
+      <textarea name="content" rows="3" required></textarea>
+    </label>
+    <button type="submit">Speichern</button>
+  </form>
+</section>
+
+<p><a href="{{ url_for('index') }}" hx-boost="true">Zurück zur Übersicht</a></p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a Flask application with SQLite models for posts and comments
- build HTMX-enhanced templates to create, list, and delete comments without full page reloads
- document setup steps for running the blog locally

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e03582113483338f8d2b8c5762372e